### PR TITLE
Run Rust tests on only 1 thread on GHA

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,10 +1,6 @@
 name: Tests
 
-on:
-  pull_request:
-  push:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   run_test_suite:


### PR DESCRIPTION
This PR sets `RUST_TEST_THREADS=1` on GHA.

It also updates actions/checkout to v4 and enables GHA on all pushes and pull requests.